### PR TITLE
Debug Circular Import Issue

### DIFF
--- a/changelist_data/storage/__init__.py
+++ b/changelist_data/storage/__init__.py
@@ -3,11 +3,10 @@
 from pathlib import Path
 
 from changelist_data.changelist import Changelist
-from changelist_data.storage.changelist_data_storage import ChangelistDataStorage
 from changelist_data.storage import file_validation, changelists_storage, workspace_storage
-from changelist_data.storage.storage_type import StorageType
-from changelist_data.xml.changelists import ChangelistsTree, new_tree
-from changelist_data.xml.workspace import WorkspaceTree
+from changelist_data.storage.changelist_data_storage import ChangelistDataStorage
+from changelist_data.storage.storage_type import StorageType, get_default_path
+from changelist_data.xml.changelists import new_tree
 
 
 def read_storage(
@@ -63,8 +62,12 @@ def load_storage(
                 return _load_option(StorageType(opts), storage_path)
     elif (storage_path := file_validation.check_if_default_file_exists(option)) is not None:
         return _load_option(option, storage_path)
-    # Create an empty Changelists Storage Tree
-    return new_tree()
+    # Create an empty Changelists Storage Tree with a default path
+    return ChangelistDataStorage(
+        new_tree(),
+        StorageType.CHANGELISTS,
+        get_default_path(StorageType.CHANGELISTS)
+    )
 
 
 def _read_option(
@@ -81,9 +84,17 @@ def _read_option(
 def _load_option(
     option: StorageType,
     path: Path
-) -> ChangelistsTree | WorkspaceTree:
+) -> ChangelistDataStorage:
     if option == StorageType.CHANGELISTS:
-        return changelists_storage.load_file(path)
+        return ChangelistDataStorage(
+            changelists_storage.load_file(path),
+            option,
+            path
+        )
     if option == StorageType.WORKSPACE:
-        return workspace_storage.load_file(path)
+        return ChangelistDataStorage(
+            workspace_storage.load_file(path),
+            option,
+            path
+        )
     raise ValueError("Invalid Storage Option")

--- a/changelist_data/storage/changelist_data_storage.py
+++ b/changelist_data/storage/changelist_data_storage.py
@@ -1,17 +1,27 @@
 """ An Abstract Class defining the interface for translation between XML Trees and Changelists.
 """
-from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
 
 from changelist_data.changelist import Changelist
+from changelist_data.storage.storage_type import StorageType
 from changelist_data.xml.base_xml_tree import BaseXMLTree
 
 
-class ChangelistDataStorage(BaseXMLTree, metaclass=ABCMeta):
+@dataclass(frozen=True)
+class ChangelistDataStorage:
+    """
+    """
+    base_xml_tree: BaseXMLTree
+    storage_type: StorageType
+    update_path: Path
 
-    @abstractmethod
     def get_changelists(self) -> list[Changelist]:
-        pass
+        return self.base_xml_tree.get_changelists()
 
-    @abstractmethod
     def update_changelists(self, changelists: list[Changelist]):
-        pass
+        self.base_xml_tree.update_changelists(changelists)
+
+    def write_to_storage(self) -> bool:
+        self.base_xml_tree.write_tree(self.update_path)
+        return True

--- a/changelist_data/storage/workspace_storage.py
+++ b/changelist_data/storage/workspace_storage.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from changelist_data.changelist import Changelist
 from changelist_data.storage import file_validation, storage_type
 from changelist_data.storage.storage_type import StorageType
-from changelist_data.xml import workspace
+from changelist_data.xml.workspace import read_xml, load_xml
 from changelist_data.xml.workspace.workspace_tree import WorkspaceTree
 
 
@@ -21,7 +21,7 @@ def read_file(
     Returns:
     list[Changelist] - The list of Changelist data stored in Workspace Storage.
     """
-    return workspace.read_xml(
+    return read_xml(
         file_validation.validate_file_input_text(file_path)
     )
 
@@ -39,7 +39,7 @@ def load_file(
     """
     if file_path is None:
         exit("Only use Workspace Tree if a Workspace XML file has been given to you.")
-    return workspace.load_xml(
+    return load_xml(
         file_validation.validate_file_input_text(file_path)
     )
 

--- a/changelist_data/xml/base_xml_tree.py
+++ b/changelist_data/xml/base_xml_tree.py
@@ -4,6 +4,8 @@ from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from xml.etree.ElementTree import ElementTree
 
+from changelist_data.changelist import Changelist
+
 
 class BaseXMLTree(metaclass=ABCMeta):
     """ A Base Abstract Class providing writing capabilities for an XML Tree class.
@@ -11,6 +13,14 @@ class BaseXMLTree(metaclass=ABCMeta):
 
     @abstractmethod
     def get_root(self) -> ElementTree:
+        pass
+
+    @abstractmethod
+    def get_changelists(self) -> list[Changelist]:
+        pass
+
+    @abstractmethod
+    def update_changelists(self, changelists: list[Changelist]):
         pass
 
     def write_tree(

--- a/changelist_data/xml/changelists/changelists_tree.py
+++ b/changelist_data/xml/changelists/changelists_tree.py
@@ -1,12 +1,13 @@
 """ XML Tree Class for Changelists Data XML.
 """
 from xml.etree.ElementTree import Element, ElementTree, indent
+
 from changelist_data.changelist import Changelist
-from changelist_data.storage.changelist_data_storage import ChangelistDataStorage
+from changelist_data.xml.base_xml_tree import BaseXMLTree
 from changelist_data.xml.changelists import changelists_reader, changelists_writer
 
 
-class ChangelistsTree(ChangelistDataStorage):
+class ChangelistsTree(BaseXMLTree):
     """
     Manages the Changelists Data XML Element Trees.
 

--- a/changelist_data/xml/workspace/workspace_tree.py
+++ b/changelist_data/xml/workspace/workspace_tree.py
@@ -3,11 +3,11 @@
 from xml.etree.ElementTree import Element, ElementTree, indent
 
 from changelist_data.changelist import Changelist
+from changelist_data.xml.base_xml_tree import BaseXMLTree
 from changelist_data.xml.workspace import workspace_writer, workspace_reader
-from changelist_data.storage.changelist_data_storage import ChangelistDataStorage
 
 
-class WorkspaceTree(ChangelistDataStorage):
+class WorkspaceTree(BaseXMLTree):
     """
     Manages the Workspace XML Element Trees.
 

--- a/test/changelist_data/storage/test_init.py
+++ b/test/changelist_data/storage/test_init.py
@@ -7,9 +7,10 @@ from unittest.mock import Mock
 import pytest
 
 import changelist_data.xml.changelists
-from changelist_data.storage import read_storage, load_storage, StorageType
-from changelist_data.xml.changelists import ChangelistsTree
-from changelist_data.xml.workspace import WorkspaceTree
+from changelist_data.storage import read_storage, load_storage
+from changelist_data.storage.storage_type import StorageType
+from changelist_data.storage.changelist_data_storage import ChangelistDataStorage
+
 from test.changelist_data.xml.changelists import provider as changelists_provider
 from test.changelist_data.xml.workspace import provider as workspace_provider
 
@@ -161,7 +162,7 @@ def test_load_storage_workspace_empty_file_raises_exit(temp_file):
 def test_load_storage_changelists_no_changelists_returns_empty_storage(temp_file):
     temp_file.write_text(changelist_data.xml.changelists.EMPTY_CHANGELISTS_DATA)
     result = load_storage(StorageType.CHANGELISTS, temp_file)
-    assert isinstance(result, ChangelistsTree)
+    assert isinstance(result, ChangelistDataStorage)
     assert len(result.get_changelists()) == 0
 
 
@@ -169,7 +170,7 @@ def test_load_storage_workspace_no_cl_manager_raises_exit(temp_file):
     temp_file.write_text(workspace_provider.get_no_changelist_xml())
     try:
         result = load_storage(StorageType.WORKSPACE, temp_file)
-        assert isinstance(result, WorkspaceTree)
+        assert isinstance(result, ChangelistDataStorage)
         assert len(result.get_changelists()) == 0
         raises_exit = False
     except SystemExit:
@@ -180,7 +181,7 @@ def test_load_storage_workspace_no_cl_manager_raises_exit(temp_file):
 def test_load_storage_workspace_empty_changelists_returns_empty_storage(temp_file):
     temp_file.write_text(workspace_provider.get_empty_changelist_xml())
     result = load_storage(StorageType.WORKSPACE, temp_file)
-    assert isinstance(result, WorkspaceTree)
+    assert isinstance(result, ChangelistDataStorage)
     assert len(result.get_changelists()) == 0
 
 


### PR DESCRIPTION
The **Storage** package depends on the **XML** Package. When **Storage** package is initialized, it imports from the **XML** package which is also initialized. 

This means that no module inside the **XML** package can import from the **Storage** package during initialization.

The **XML** modules may import from the **Changelist_Data** Package, including the data classes `FileChange` and `Changelist`, but they may not import from **Storage** modules.

## The Blame
The cause of this issue is that both XML Trees are extending the `ChangelistDataStorage` abstract class. This is a **Storage** package class which should not have been allowed.

## Resolution
The XML Trees will extend the `BaseXMLTree` abstract class instead of `ChangelistDataStorage`.

The `ChangelistDataStorage` class will become a frozen data class that contains the `BaseXMLTree` instance as a field.

## Additional Usability Improvements
During integration, a few design issues were noticed.
The StorageType and UpdatePath fields added to the `ChangelistDataStorage` class will make storage much easier to use.

