### PR TITLE
Release 0.1.5

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     strategy:
-      max-parallel: 4
+      max-parallel: 6
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [ '3.10', '3.11', '3.12' , '3.13' ]
@@ -27,7 +27,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov==5.0.0
+          pip install pytest==8.3.4 pytest-cov==5.0.0
 
       - name: Run unit tests
         run: pytest test/ --cov=changelist_data --cov-report=html --cov-fail-under=93

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@v2.1.2rc1-dk96-os
+        uses: dk96-os/gh-action-sigstore-python@v3.1-dk96-os
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/changelist_data/storage/__init__.py
+++ b/changelist_data/storage/__init__.py
@@ -14,10 +14,10 @@ def read_storage(
     file_path: Path | None = None,
 ) -> list[Changelist]:
     """ Read Changelist Data from Storage into a List of Changelist data.
-        None values indicate that the storage file should be searched for using default values.
+        - None values indicate that the storage file should be searched for using default values.
 
     Parameters:
-    - option (StorageType | None): The Storage Type describing the XML format. Use None to search all StorageTypes in order.
+    - option (StorageType | None): The Storage Type describing the XML format. Search all StorageTypes in order by default.
     - file_path (Path | None): The file path to read from. Use None to look in default storage locations.
 
     Returns:
@@ -29,12 +29,23 @@ def read_storage(
         return _read_option(option, file_path)
     # Find and Read from Default File Paths
     if option is None:
-        for opts in StorageType:
-            if (storage_path := file_validation.check_if_default_file_exists(StorageType(opts))) is not None:
-                return _read_option(StorageType(opts), storage_path)
+        if (storage_result := read_any_storage_option()) is not None:
+            return storage_result
     elif (storage_path := file_validation.check_if_default_file_exists(option)) is not None:
         return _read_option(option, storage_path)
     return []
+
+
+def read_any_storage_option() -> list[Changelist] | None:
+    """ Check the default locations for all storage options.
+        - First checks Changelists, then Workspace locations.
+
+    Returns:
+    list[Changelist]? - The list of Changelist data objects read from the file, or None.
+    """
+    for opts in StorageType:
+        if (storage_path := file_validation.check_if_default_file_exists(StorageType(opts))) is not None:
+            return _read_option(StorageType(opts), storage_path)
 
 
 def load_storage(
@@ -57,9 +68,8 @@ def load_storage(
         return _load_option(option, file_path)
     # Find and Read from Default File Paths
     if option is None:
-        for opts in StorageType:
-            if (storage_path := file_validation.check_if_default_file_exists(StorageType(opts))) is not None:
-                return _load_option(StorageType(opts), storage_path)
+        if (storage_result := load_any_storage_option()) is not None:
+            return storage_result
     elif (storage_path := file_validation.check_if_default_file_exists(option)) is not None:
         return _load_option(option, storage_path)
     # Create an empty Changelists Storage Tree with a default path
@@ -68,6 +78,19 @@ def load_storage(
         StorageType.CHANGELISTS,
         get_default_path(StorageType.CHANGELISTS)
     )
+
+
+def load_any_storage_option() -> ChangelistDataStorage | None:
+    """ Check the default locations for all storage options.
+        - First checks Changelists, then Workspace locations.
+        - Returns None if no file is found.
+
+    Returns:
+    ChangelistDataStorage? - The data object providing a read and write interface for the storage file.
+    """
+    for opts in StorageType:
+        if (storage_path := file_validation.check_if_default_file_exists(StorageType(opts))) is not None:
+            return _load_option(StorageType(opts), storage_path)
 
 
 def _read_option(

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ from setuptools import setup, find_packages
 
 setup(
     name="changelist-data",
-    version="0.1.4",
-	description='Data Management base package for Changelists CLI Tools',
+    version="0.1.5",
+	description='Data package for Changelists CLI Tools',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
 	author='DK96-OS',
@@ -16,7 +16,7 @@ setup(
         "Source Code": "https://github.com/DK96-OS/changelist-data/"
 	},
 	license='GPLv3',
-    packages=find_packages(exclude=['test']),
+    packages=find_packages(exclude=['test', 'test.*']),
     entry_points={
         'console_scripts': [],
     },


### PR DESCRIPTION
## Build Improvements
- Sigstore 2 -> 3
- Stop packaging tests with dists

## CL-Data Storage Package
Create two new methods that check the default storage locations in order.
- Enables optimization in use cases where there are no arguments
- Methods start with `read_` and `load_` corresponding to read and load file requirements
- Methods end with `any_storage_option`